### PR TITLE
fix: 길이 입력 UX 개선

### DIFF
--- a/src/components/controls/PasswordControls.tsx
+++ b/src/components/controls/PasswordControls.tsx
@@ -15,7 +15,7 @@ const PasswordLengthControl = ({
   length,
   onLengthChange
 }: PasswordLengthControlProps) => {
-  const [localLength, setLocalLength] = useState(length);
+  const [localLength, setLocalLength] = useState<number | string>(length);
   const containerStyles = css({ spaceY: "2" });
 
   const inputStyles = css({
@@ -42,6 +42,20 @@ const PasswordLengthControl = ({
     }
   });
 
+  const rangeStyles = css({
+    w: "full",
+    padding: "2",
+    border: "1px solid",
+    borderColor: "gray.300",
+    borderRadius: "md",
+    fontSize: "sm",
+    _focus: {
+      outline: "2px solid",
+      outlineColor: "blue.500",
+      outlineOffset: "2px"
+    }
+  });
+
   const debouncedOnLengthChange = useDebounce((value: number) => {
     onLengthChange(value);
   }, 300);
@@ -51,23 +65,43 @@ const PasswordLengthControl = ({
   }, [length]);
 
   const handlePasswordChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = Number(e.target.value);
+    const inputValue = e.target.value;
 
-    if (isNaN(value) || value < PASSWORD_LENGTH.MIN) {
-      setLocalLength(PASSWORD_LENGTH.MIN);
-      debouncedOnLengthChange(PASSWORD_LENGTH.MIN);
+    // Allow empty string while typing
+    if (inputValue === "") {
+      setLocalLength("");
       return;
     }
 
-    if (value > PASSWORD_LENGTH.MAX) {
+    const value = Number(inputValue);
+
+    // Only update if it's a valid number
+    if (!isNaN(value)) {
+      setLocalLength(value);
+    }
+  };
+
+  const handleBlur = () => {
+    let finalValue = localLength;
+
+    // Convert empty string or non-number to MIN
+    if (finalValue === "" || isNaN(Number(finalValue))) {
+      finalValue = PASSWORD_LENGTH.MIN;
+    } else {
+      finalValue = Number(finalValue);
+    }
+
+    // Clamp to valid range
+    if (finalValue < PASSWORD_LENGTH.MIN) {
       toast.error(ERROR_MESSAGES.PASSWORD_LENGTH_MAX(PASSWORD_LENGTH.MAX));
-      setLocalLength(PASSWORD_LENGTH.MAX);
-      debouncedOnLengthChange(PASSWORD_LENGTH.MAX);
-      return;
+      finalValue = PASSWORD_LENGTH.MIN;
+    } else if (finalValue > PASSWORD_LENGTH.MAX) {
+      toast.error(ERROR_MESSAGES.PASSWORD_LENGTH_MAX(PASSWORD_LENGTH.MAX));
+      finalValue = PASSWORD_LENGTH.MAX;
     }
 
-    setLocalLength(value);
-    debouncedOnLengthChange(value);
+    setLocalLength(finalValue);
+    debouncedOnLengthChange(finalValue);
   };
 
   return (
@@ -82,19 +116,30 @@ const PasswordLengthControl = ({
         min={PASSWORD_LENGTH.MIN}
         max={PASSWORD_LENGTH.MAX}
         aria-label="비밀번호 길이"
-        aria-valuemin={PASSWORD_LENGTH.MIN}
-        aria-valuemax={PASSWORD_LENGTH.MAX}
-        aria-valuenow={localLength}
         value={localLength}
         onChange={handlePasswordChange}
+        onBlur={handleBlur}
         className={inputStyles}
         step={1}
+      />
+      <input
+        type="range"
+        min={PASSWORD_LENGTH.MIN}
+        max={PASSWORD_LENGTH.MAX}
+        value={typeof localLength === "string" ? PASSWORD_LENGTH.MIN : localLength}
+        onChange={(e) => {
+          const value = Number(e.target.value);
+          setLocalLength(value);
+          debouncedOnLengthChange(value);
+        }}
+        className={rangeStyles}
+        aria-label="비밀번호 길이 슬라이더"
       />
       <div id="password-length-description" className="sr-only">
         비밀번호 길이를 {PASSWORD_LENGTH.MIN}자에서 {PASSWORD_LENGTH.MAX}자
         사이로 조절할 수 있습니다.
       </div>
-      <PasswordLength passwordLength={Math.round(localLength)} />
+      <PasswordLength passwordLength={Math.round(typeof localLength === "string" ? PASSWORD_LENGTH.MIN : localLength)} />
     </div>
   );
 };


### PR DESCRIPTION
## 개요
길이 입력 UX의 타이핑 불가 문제를 해결하고 범위 슬라이더를 추가했습니다.

## 변경 내용
- **입력 중 자유로운 타이핑**: MIN 클램프 제거로 "24"와 같은 숫자 타이핑 가능
- **지연된 유효성 검사**: 포커스 해제 시에만 범위 검사 및 클램핑 수행
- **범위 슬라이더 추가**: 숫자 입력과 양방향 동기화되는 슬라이더
- **ARIA 정리**: 네이티브 number input에 불필요한 aria-valuemin/max/now 제거

## 검증
- ✅ \`npm test\` 통과 (12 tests)
- ✅ \`npm run build\` 성공
- ✅ 타이핑 테스트: "2" 입력 후 "4" 입력하면 24로 표시됨
- ✅ 범위 벗어난 값: blur 시 토스트 표시 후 클램핑
- ✅ 슬라이더-입력 동기화 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)