### PR TITLE
feat: 비밀번호 생성 이력 기능 추가

### DIFF
--- a/src/components/PasswordGenerator.tsx
+++ b/src/components/PasswordGenerator.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useRef, useEffect } from "react";
 import { generateSecurePassword } from "../utils/passwordGenerator";
 import PasswordDisplay from "./PasswordDisplay";
 import PasswordOptions from "./options/PasswordOption";
+import PasswordHistory from "./PasswordHistory";
 import { css } from "../../styled-system/css";
 import { PasswordOptions as PasswordOptionsType } from "../types/password";
 import { useDebounce } from "../utils/debounce";
@@ -57,6 +58,7 @@ const PasswordGenerator = () => {
   });
 
   const [options, setOptions] = useState<PasswordOptionsType>(DEFAULT_PASSWORD_OPTIONS);
+  const [history, setHistory] = useState<string[]>([]);
 
   const [hasEmptyPasswordWarning, setHasEmptyPasswordWarning] = useState(false);
   const {
@@ -85,6 +87,7 @@ const PasswordGenerator = () => {
 
       setHasEmptyPasswordWarning(false);
       setPassword(newPassword);
+      setHistory((prev) => [newPassword, ...prev].slice(0, 10));
       checkPwned(newPassword);
     },
     [checkPwned]
@@ -159,6 +162,7 @@ const PasswordGenerator = () => {
         </div>
       )}
       <PasswordOptions options={options} onChange={onChangeOptions} />
+      <PasswordHistory history={history} />
     </div>
   );
 };

--- a/src/components/PasswordHistory.tsx
+++ b/src/components/PasswordHistory.tsx
@@ -1,0 +1,126 @@
+import { memo } from "react";
+import { css } from "../../styled-system/css";
+import CopyIcon from "./CopyIcon";
+import { toast } from "react-toastify";
+
+interface PasswordHistoryProps {
+  history: string[];
+}
+
+const maskPassword = (password: string): string => {
+  if (password.length <= 6) return password;
+  return password.slice(0, 3) + "•".repeat(password.length - 6) + password.slice(-3);
+};
+
+const PasswordHistory = ({ history }: PasswordHistoryProps) => {
+  const handleCopy = async (password: string) => {
+    if (!navigator.clipboard) {
+      toast.error("클립보드 기능을 사용할 수 없습니다.");
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(password);
+      toast.success("비밀번호가 복사되었습니다.");
+    } catch (error) {
+      toast.error("비밀번호 복사에 실패했습니다.");
+    }
+  };
+
+  if (history.length === 0) {
+    return null;
+  }
+
+  return (
+    <details
+      className={css({
+        p: 4,
+        borderRadius: "md",
+        bg: "muted",
+        cursor: "pointer"
+      })}
+    >
+      <summary
+        className={css({
+          fontWeight: "medium",
+          fontSize: "sm",
+          color: "text",
+          userSelect: "none",
+          _hover: {
+            opacity: 0.8
+          }
+        })}
+      >
+        생성 이력 ({history.length}/10)
+      </summary>
+      <div
+        className={css({
+          spaceY: 2,
+          mt: 3
+        })}
+      >
+        {history.map((password, index) => (
+          <div
+            key={`${password}-${index}`}
+            className={css({
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              gap: 2,
+              p: 2,
+              bg: "card",
+              borderRadius: "sm",
+              fontSize: "sm"
+            })}
+          >
+            <span
+              className={css({
+                fontFamily: "monospace",
+                flex: 1,
+                minWidth: 0,
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap"
+              })}
+              title={password}
+            >
+              {maskPassword(password)}
+            </span>
+            <button
+              type="button"
+              onClick={() => handleCopy(password)}
+              className={css({
+                display: "inline-flex",
+                alignItems: "center",
+                justifyContent: "center",
+                minWidth: "36px",
+                minHeight: "36px",
+                background: "none",
+                border: "none",
+                cursor: "pointer",
+                color: "text",
+                borderRadius: "sm",
+                padding: 1,
+                transition: "all 0.2s",
+                _hover: {
+                  opacity: 0.8,
+                  bg: "muted"
+                },
+                _focus: {
+                  outline: "2px solid",
+                  outlineColor: "ring",
+                  outlineOffset: "2px"
+                }
+              })}
+              aria-label={`${maskPassword(password)} 복사하기`}
+            >
+              <CopyIcon aria-hidden="true" />
+            </button>
+          </div>
+        ))}
+      </div>
+    </details>
+  );
+};
+
+export default memo(PasswordHistory);


### PR DESCRIPTION
## 개요
사용자가 생성한 비밀번호의 이력을 인메모리로 관리하고 표시하는 기능을 추가했습니다.

## 변경 내용
- **PasswordHistory.tsx** (신규): 생성 이력을 표시하는 컴포넌트
  - `<details>`/`<summary>` 엘리먼트로 기본 축소 상태
  - 마스킹 처리: 첫 3자 + 마지막 3자 + 중간 점(•)으로 표시
  - 각 항목마다 복사 버튼 제공
  - 기존 CopyIcon과 복사 로직 재사용

- **PasswordGenerator.tsx** (수정):
  - `history` 상태 추가 (최대 10개)
  - 비밀번호 생성 성공 시 `setHistory(prev => [newPassword, ...prev].slice(0, 10))`로 이력 업데이트
  - PasswordHistory 컴포넌트를 PasswordOptions 아래에 렌더링

## 기술 세부사항
- 토큰 기반 스타일링: 기존 panda.config.ts의 `text`, `muted`, `card` 등 의미론적 색상 사용
- 보안: localStorage 미사용 (세션 내 인메모리만)
- 접근성: aria-label 및 마스킹된 비밀번호의 title 속성으로 전체 비밀번호 확인 가능

## 검증
- ✓ npm test: 12개 테스트 모두 통과
- ✓ npm run build: 빌드 성공
- ✓ 마스킹 로직: 6자 이하는 그대로, 6자 초과는 양끝 3자 + 중간 점
- ✓ 복사 기능: 기존 패턴 재사용으로 안정성 확보

🤖 Generated with [Claude Code](https://claude.com/claude-code)