### PR TITLE
fix: passphrase 모드 엔트로피 강도 표시 및 구분자 UI 개선

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -15,8 +15,8 @@
     -->
         <link rel="manifest" href="/manifest.json" />
         <title>랜덤 비밀번호 생성기</title>
-      <script type="module" crossorigin src="/assets/index-gYovltbf.js"></script>
-      <link rel="stylesheet" crossorigin href="/assets/index-qMkEGyCO.css">
+      <script type="module" crossorigin src="/assets/index-C_wBhX6A.js"></script>
+      <link rel="stylesheet" crossorigin href="/assets/index-D-qYyMe6.css">
     </head>
     <body>
         <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/components/PasswordDisplay.tsx
+++ b/src/components/PasswordDisplay.tsx
@@ -1,4 +1,4 @@
-import { useState, memo, lazy, Suspense } from "react";
+import { useState, memo, lazy, Suspense, useMemo } from "react";
 import { css } from "../../styled-system/css";
 import CopyIcon from "./CopyIcon";
 import EyeOff from "../assets/eye-off-1.svg";
@@ -6,6 +6,9 @@ import EyeOn from "../assets/eye-1.svg";
 import RefreshIcon from "./RefreshIcon";
 import { toast } from "react-toastify";
 import KakaoButton from "./KakaoButton";
+import { getPassphraseEntropy } from "../utils/passwordGenerator";
+import { getStrengthLabel } from "../utils/strengthLevel";
+import { PassphraseOptions } from "../types/password";
 
 // 코드 스플리팅: zxcvbn 라이브러리(~800KB)를 포함하는 컴포넌트를 지연 로딩
 const PasswordStrengthIndicator = lazy(
@@ -15,11 +18,25 @@ const PasswordStrengthIndicator = lazy(
 interface PasswordDisplayProps {
   password: string;
   onRefresh: () => void;
+  mode?: string;
+  passphraseOptions?: Partial<PassphraseOptions>;
 }
 
-const PasswordDisplay = ({ password, onRefresh }: PasswordDisplayProps) => {
+const PasswordDisplay = ({
+  password,
+  onRefresh,
+  mode = "password",
+  passphraseOptions
+}: PasswordDisplayProps) => {
   const [showPassword, setShowPassword] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
+
+  const entropy = useMemo(() => {
+    if (mode === "passphrase") {
+      return getPassphraseEntropy(passphraseOptions);
+    }
+    return 0;
+  }, [mode, passphraseOptions]);
 
   const handlePasswordCopy = async () => {
     if (!navigator.clipboard) {
@@ -173,35 +190,96 @@ const PasswordDisplay = ({ password, onRefresh }: PasswordDisplayProps) => {
         </div>
       </div>
 
-      <Suspense
-        fallback={
+      {mode === "passphrase" ? (
+        <div
+          className={css({
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            marginTop: "4"
+          })}
+          id="password-strength"
+          role="status"
+          aria-live="polite"
+          aria-label={`Passphrase 강도: ${getStrengthLabel(entropy)}`}
+        >
           <div
             className={css({
-              display: "flex",
-              flexDirection: "column",
-              alignItems: "center",
-              marginTop: "4",
-              minHeight: "40px",
-              justifyContent: "center"
+              width: "100%",
+              backgroundColor: "gray.200",
+              borderRadius: "full",
+              height: "2.5",
+              _dark: {
+                backgroundColor: "gray.700"
+              }
             })}
+            role="progressbar"
+            aria-valuenow={Math.round(entropy)}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-label="Passphrase 엔트로피 수준"
           >
             <div
               className={css({
-                display: "inline-block",
-                width: "20px",
-                height: "20px",
-                border: "3px solid",
-                borderColor: "border",
-                borderTopColor: "muted-foreground",
+                height: "2.5",
                 borderRadius: "full",
-                animation: "spin 0.6s linear infinite"
+                transition: "width 0.3s ease",
+                width: `${Math.min(entropy / 100, 1) * 100}%`,
+                backgroundColor:
+                  entropy >= 80
+                    ? "#2563eb"
+                    : entropy >= 60
+                    ? "#16a34a"
+                    : entropy >= 50
+                    ? "#eab308"
+                    : "#f97316"
               })}
             />
           </div>
-        }
-      >
-        <PasswordStrengthIndicator password={password} />
-      </Suspense>
+          <p
+            className={css({
+              fontSize: "sm",
+              marginTop: "2",
+              color: "gray.600",
+              _dark: {
+                color: "gray.300"
+              }
+            })}
+          >
+            {getStrengthLabel(entropy)} ({entropy.toFixed(1)} bits)
+          </p>
+        </div>
+      ) : (
+        <Suspense
+          fallback={
+            <div
+              className={css({
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                marginTop: "4",
+                minHeight: "40px",
+                justifyContent: "center"
+              })}
+            >
+              <div
+                className={css({
+                  display: "inline-block",
+                  width: "20px",
+                  height: "20px",
+                  border: "3px solid",
+                  borderColor: "border",
+                  borderTopColor: "muted-foreground",
+                  borderRadius: "full",
+                  animation: "spin 0.6s linear infinite"
+                })}
+              />
+            </div>
+          }
+        >
+          <PasswordStrengthIndicator password={password} />
+        </Suspense>
+      )}
 
       <div
         className={css({

--- a/src/components/PasswordGenerator.tsx
+++ b/src/components/PasswordGenerator.tsx
@@ -125,7 +125,12 @@ const PasswordGenerator = () => {
 
   return (
     <div className={containerStyles}>
-      <PasswordDisplay password={password} onRefresh={handleGeneratePassword} />
+      <PasswordDisplay
+        password={password}
+        onRefresh={handleGeneratePassword}
+        mode={options.mode}
+        passphraseOptions={options.passphraseOptions}
+      />
       {isCheckingPwned && (
         <div className={loadingStyles} role="status" aria-live="polite">
           <span

--- a/src/components/options/PasswordOption.tsx
+++ b/src/components/options/PasswordOption.tsx
@@ -8,15 +8,9 @@ import {
 } from "../../constants/passwordConfig";
 import CheckboxOption from "./CheckboxOption";
 import { getPassphraseEntropy } from "../../utils/passwordGenerator";
+import { getStrengthLabel } from "../../utils/strengthLevel";
 
 const ENTROPY_WARNING_THRESHOLD = 50;
-
-const getStrengthLabel = (bits: number): string => {
-  if (bits >= 80) return "매우 강함";
-  if (bits >= 60) return "강함";
-  if (bits >= ENTROPY_WARNING_THRESHOLD) return "보통";
-  return "약함";
-};
 
 interface PasswordOptionsProps {
   options: PasswordOptionsType;
@@ -158,11 +152,61 @@ const PasswordOptions = ({ options, onChange }: PasswordOptionsProps) => {
             </p>
           </div>
           <div>
-            <label className={labelStyles} htmlFor="passphrase-separator">
+            <label className={labelStyles}>
               구분자
             </label>
+            <div
+              className={css({
+                display: "grid",
+                gridTemplateColumns: "repeat(4, 1fr)",
+                gap: 2,
+                marginBottom: 2
+              })}
+            >
+              {["-", ".", "_", " "].map((sep) => (
+                <button
+                  key={sep}
+                  type="button"
+                  onClick={() =>
+                    onChange({
+                      passphraseOptions: {
+                        ...passphraseOptions,
+                        separator: sep
+                      }
+                    })
+                  }
+                  className={css({
+                    padding: "2",
+                    borderRadius: "md",
+                    border: "2px solid",
+                    borderColor:
+                      passphraseOptions.separator === sep
+                        ? "blue.500"
+                        : "gray.300",
+                    backgroundColor:
+                      passphraseOptions.separator === sep
+                        ? "blue.50"
+                        : "white",
+                    cursor: "pointer",
+                    fontWeight: "medium",
+                    transition: "all 0.2s",
+                    _hover: {
+                      borderColor: "blue.500"
+                    },
+                    _focus: {
+                      outline: "2px solid",
+                      outlineColor: "blue.500",
+                      outlineOffset: "2px"
+                    }
+                  })}
+                  aria-label={`구분자: ${sep === " " ? "공백" : sep}`}
+                  aria-pressed={passphraseOptions.separator === sep}
+                >
+                  {sep === " " ? "공백" : sep}
+                </button>
+              ))}
+            </div>
             <input
-              id="passphrase-separator"
               type="text"
               value={passphraseOptions.separator || " "}
               onChange={(e) =>
@@ -175,7 +219,8 @@ const PasswordOptions = ({ options, onChange }: PasswordOptionsProps) => {
               }
               className={inputStyles}
               maxLength={1}
-              placeholder=" "
+              placeholder="커스텀"
+              aria-label="커스텀 구분자"
             />
           </div>
           <CheckboxOption

--- a/src/utils/strengthLevel.ts
+++ b/src/utils/strengthLevel.ts
@@ -1,3 +1,5 @@
+const ENTROPY_WARNING_THRESHOLD = 50;
+
 export interface StrengthLevel {
     level: string;
     message: string;
@@ -43,3 +45,10 @@ export const strengthLevels: StrengthLevel[] = [
         score: 4
     }
 ];
+
+export const getStrengthLabel = (bits: number): string => {
+    if (bits >= 80) return "매우 강함";
+    if (bits >= 60) return "강함";
+    if (bits >= ENTROPY_WARNING_THRESHOLD) return "보통";
+    return "약함";
+};


### PR DESCRIPTION
## 개요

passphrase 모드에서 zxcvbn 기반 강도 표시 대신 엔트로피 기반 표시로 개선하고, 구분자 선택 UI를 개선했습니다.

## 변경 내용

- **엔트로피 기반 강도 표시**: passphrase 모드에서 zxcvbn 대신 getPassphraseEntropy를 사용하여 엔트로피(bits) 기반으로 강도 표시
- **코드 재사용**: getStrengthLabel 함수를 strengthLevel.ts로 추출하여 PasswordOption과 PasswordDisplay에서 공유
- **Props 전달**: PasswordGenerator에서 mode와 passphraseOptions를 PasswordDisplay로 전달
- **조건부 렌더링**: passphrase 모드일 때 엔트로피 바, 일반 모드일 때 zxcvbn 바 표시
- **구분자 UI 개선**: 자유 텍스트 입력에서 버튼 그룹(-, ., _, 공백) + 커스텀 텍스트 입력으로 개선

## 검증

- vitest 모두 통과 (12 tests passed)
- npm run build 성공
- passphrase 모드에서 단어 개수 변경 시 엔트로피 바 반응 확인 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)