### PR TITLE
feat: 커스텀 제외 문자 기능 추가

### DIFF
--- a/src/components/options/PasswordCharacterOptions.tsx
+++ b/src/components/options/PasswordCharacterOptions.tsx
@@ -42,6 +42,27 @@ const PasswordCharacterOptions = ({
     return checkedCount === 1 && options[key as keyof CharacterOptions];
   };
 
+  const labelStyles = css({
+    fontSize: "sm",
+    fontWeight: "medium",
+    color: "text",
+    marginBottom: "1"
+  });
+
+  const inputStyles = css({
+    w: "full",
+    padding: "2",
+    border: "1px solid",
+    borderColor: "border",
+    borderRadius: "md",
+    fontSize: "sm",
+    _focus: {
+      outline: "2px solid",
+      outlineColor: "primary",
+      outlineOffset: "2px"
+    }
+  });
+
   return (
     <div
       className={containerStyles}
@@ -69,6 +90,19 @@ const PasswordCharacterOptions = ({
           />
         );
       })}
+      <div className={css({ spaceY: "1" })}>
+        <label className={labelStyles} htmlFor="custom-exclude">
+          제외할 문자
+        </label>
+        <input
+          id="custom-exclude"
+          type="text"
+          value={options.customExclude || ""}
+          onChange={(e) => onOptionsChange({ customExclude: e.target.value })}
+          className={inputStyles}
+          placeholder="제외할 문자를 입력하세요 (예: !@#)"
+        />
+      </div>
     </div>
   );
 };

--- a/src/types/password.ts
+++ b/src/types/password.ts
@@ -4,6 +4,7 @@ export interface CharacterOptions {
   numbers: boolean;
   special: boolean;
   excludeAmbiguous: boolean;
+  customExclude?: string;
 }
 
 export interface PassphraseOptions {

--- a/src/utils/passwordGenerator.test.ts
+++ b/src/utils/passwordGenerator.test.ts
@@ -6,7 +6,8 @@ import { wordLists } from "../constants/wordLists";
 import { PASSPHRASE_CONFIG } from "../constants/passwordConfig";
 import {
     generateSecurePassphrase,
-    getPassphraseEntropy
+    getPassphraseEntropy,
+    generateSecurePassword
 } from "./passwordGenerator";
 
 describe("wordLists.en", () => {
@@ -99,5 +100,78 @@ describe("getPassphraseEntropy", () => {
         const base = getPassphraseEntropy({ words: 5, includeNumber: false });
         const withNumber = getPassphraseEntropy({ words: 5, includeNumber: true });
         expect(withNumber).toBeCloseTo(base + Math.log2(90) + Math.log2(6), 5);
+    });
+});
+
+describe("generateSecurePassword with customExclude", () => {
+    it("제외 문자 포함 안 됨", () => {
+        const password = generateSecurePassword({
+            length: 50,
+            lowercase: true,
+            uppercase: true,
+            numbers: true,
+            special: true,
+            excludeAmbiguous: false,
+            customExclude: "!@#"
+        });
+
+        expect(password).not.toMatch(/[!@#]/);
+    });
+
+    it("여러 제외 문자 필터링", () => {
+        const password = generateSecurePassword({
+            length: 100,
+            lowercase: true,
+            uppercase: true,
+            numbers: true,
+            special: true,
+            excludeAmbiguous: false,
+            customExclude: "abc123"
+        });
+
+        expect(password).not.toMatch(/[abc123]/);
+    });
+
+    it("모든 문자가 제외되면 빈 문자열", () => {
+        const password = generateSecurePassword({
+            length: 12,
+            lowercase: true,
+            uppercase: false,
+            numbers: false,
+            special: false,
+            excludeAmbiguous: false,
+            customExclude: "abcdefghijklmnopqrstuvwxyz"
+        });
+
+        expect(password).toBe("");
+    });
+
+    it("빈 customExclude는 모든 문자 포함", () => {
+        const password = generateSecurePassword({
+            length: 12,
+            lowercase: true,
+            uppercase: true,
+            numbers: true,
+            special: true,
+            excludeAmbiguous: false,
+            customExclude: ""
+        });
+
+        expect(password.length).toBe(12);
+        expect(password).not.toBe("");
+    });
+
+    it("customExclude 없으면 정상 작동", () => {
+        const password = generateSecurePassword({
+            length: 12,
+            lowercase: true,
+            uppercase: true,
+            numbers: true,
+            special: true,
+            excludeAmbiguous: false
+        });
+
+        expect(password.length).toBe(12);
+        expect(password).not.toBe("");
     });
 });

--- a/src/utils/passwordGenerator.ts
+++ b/src/utils/passwordGenerator.ts
@@ -254,19 +254,25 @@ export const generateSecurePassword = (options: {
 
     const { length, lowercase, uppercase, numbers, special, excludeAmbiguous, customExclude } = options;
 
-    const characterSets = getCharacterSets(excludeAmbiguous);
-    let allChars = buildCharacterPool(characterSets, {
+    let characterSets = getCharacterSets(excludeAmbiguous);
+
+    // Filter each character set by customExclude BEFORE pool building and guaranteed injection
+    if (customExclude) {
+        const excludeSet = new Set(customExclude);
+        characterSets = {
+            lowercase: characterSets.lowercase.split("").filter((char) => !excludeSet.has(char)).join(""),
+            uppercase: characterSets.uppercase.split("").filter((char) => !excludeSet.has(char)).join(""),
+            numbers: characterSets.numbers.split("").filter((char) => !excludeSet.has(char)).join(""),
+            special: characterSets.special.split("").filter((char) => !excludeSet.has(char)).join("")
+        };
+    }
+
+    const allChars = buildCharacterPool(characterSets, {
         lowercase,
         uppercase,
         numbers,
         special
     });
-
-    // Filter out custom excluded characters
-    if (customExclude) {
-        const excludeSet = new Set(customExclude);
-        allChars = allChars.split("").filter((char) => !excludeSet.has(char)).join("");
-    }
 
     if (allChars.length === 0) {
         return "";

--- a/src/utils/passwordGenerator.ts
+++ b/src/utils/passwordGenerator.ts
@@ -242,6 +242,7 @@ export const generateSecurePassword = (options: {
     numbers: boolean;
     special: boolean;
     excludeAmbiguous: boolean;
+    customExclude?: string;
     mode?: "password" | "passphrase";
     passphraseOptions?: Partial<PassphraseOptions>;
 }): string => {
@@ -251,15 +252,21 @@ export const generateSecurePassword = (options: {
         return generateSecurePassphrase(passphraseOptions);
     }
 
-    const { length, lowercase, uppercase, numbers, special, excludeAmbiguous } = options;
+    const { length, lowercase, uppercase, numbers, special, excludeAmbiguous, customExclude } = options;
 
     const characterSets = getCharacterSets(excludeAmbiguous);
-    const allChars = buildCharacterPool(characterSets, {
+    let allChars = buildCharacterPool(characterSets, {
         lowercase,
         uppercase,
         numbers,
         special
     });
+
+    // Filter out custom excluded characters
+    if (customExclude) {
+        const excludeSet = new Set(customExclude);
+        allChars = allChars.split("").filter((char) => !excludeSet.has(char)).join("");
+    }
 
     if (allChars.length === 0) {
         return "";


### PR DESCRIPTION
## 개요
비밀번호 생성 시 사용자가 특정 문자를 제외할 수 있는 기능을 추가했습니다.

## 변경 내용
- **타입**: `CharacterOptions`에 `customExclude?: string` 옵션 추가
- **로직**: 문자 풀 구성 후 커스텀 제외 문자를 필터링하여 생성된 비밀번호에 포함되지 않도록 처리
- **UI**: 비밀번호 모드에서 "제외할 문자" 텍스트 입력 필드 추가 (기존 체크박스 아래)
- **테스트**: 5개의 테스트 케이스 추가
  - 제외 문자가 생성된 비밀번호에 포함되지 않는지 확인
  - 여러 제외 문자 동시 필터링
  - 모든 문자가 제외된 경우 빈 문자열 반환
  - 빈 제외 문자열과 미정의 처리
  - 기본 동작 유지

## 검증
✅ `npm test` - 17/17 테스트 통과
✅ `npm run build` - 빌드 성공
✅ TypeScript 타입 체크 통과
✅ 빈 문자 풀 시 기존 경고 경로 재사용

🤖 Generated with [Claude Code](https://claude.com/claude-code)