### PR TITLE
fix: UI 폴리시 3건

### DIFF
--- a/panda.config.ts
+++ b/panda.config.ts
@@ -13,6 +13,12 @@ export default defineConfig({
     // Useful for theme customization
     theme: {
         extend: {
+            keyframes: {
+                "spin-once": {
+                    from: { transform: "rotate(0deg)" },
+                    to: { transform: "rotate(360deg)" }
+                }
+            },
             semanticTokens: {
                 colors: {
                     primary: {

--- a/src/components/PasswordDisplay.tsx
+++ b/src/components/PasswordDisplay.tsx
@@ -29,7 +29,8 @@ const PasswordDisplay = ({
   passphraseOptions
 }: PasswordDisplayProps) => {
   const [showPassword, setShowPassword] = useState(false);
-  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [showCopyFeedback, setShowCopyFeedback] = useState(false);
+  const [refreshKey, setRefreshKey] = useState(0);
 
   const entropy = useMemo(() => {
     if (mode === "passphrase") {
@@ -46,16 +47,17 @@ const PasswordDisplay = ({
 
     try {
       await navigator.clipboard.writeText(password);
-      toast.success("비밀번호가 복사되었습니다.");
+      setShowCopyFeedback(true);
+      const timeout = setTimeout(() => setShowCopyFeedback(false), 1500);
+      return () => clearTimeout(timeout);
     } catch (error) {
       toast.error("비밀번호 복사에 실패했습니다.");
     }
   };
 
   const handleRefresh = () => {
-    setIsRefreshing(true);
+    setRefreshKey((prev) => prev + 1);
     onRefresh();
-    setTimeout(() => setIsRefreshing(false), 500);
   };
 
   return (
@@ -341,7 +343,7 @@ const PasswordDisplay = ({
           aria-label="비밀번호 클립보드에 복사하기"
         >
           <CopyIcon aria-hidden="true" />
-          복사하기
+          {showCopyFeedback ? "복사됨 ✓" : "복사하기"}
         </button>
         <button
           type="button"
@@ -377,11 +379,11 @@ const PasswordDisplay = ({
           aria-label="새로운 비밀번호 생성하기"
         >
           <div
+            key={refreshKey}
             className={css({
               display: "flex",
               alignItems: "center",
-              transition: "transform 0.5s ease-in-out",
-              transform: isRefreshing ? "rotate(180deg)" : "rotate(0deg)"
+              animation: "spin-once 0.36s ease-in-out"
             })}
           >
             <RefreshIcon aria-hidden="true" />

--- a/src/components/options/CheckboxOption.tsx
+++ b/src/components/options/CheckboxOption.tsx
@@ -6,13 +6,15 @@ interface CheckboxOptionProps {
     onChange: (checked: boolean) => void;
     label: string;
     description?: string;
+    disabled?: boolean;
 }
 
 const CheckboxOption = ({
     checked,
     onChange,
     label,
-    description
+    description,
+    disabled = false
 }: CheckboxOptionProps) => {
     // 고유 ID 생성 (description이 있을 경우 aria-describedby에 사용)
     const descriptionId = description ? `desc-${label.replace(/\s+/g, "-")}` : undefined;
@@ -22,12 +24,13 @@ const CheckboxOption = ({
         alignItems: "center",
         gap: "2",
         spaceX: "2",
-        cursor: "pointer",
+        cursor: disabled ? "not-allowed" : "pointer",
         padding: "1",
         borderRadius: "md",
+        opacity: disabled ? 0.6 : 1,
         _hover: {
-            color: "text",
-            backgroundColor: "muted"
+            color: disabled ? "inherit" : "text",
+            backgroundColor: disabled ? "transparent" : "muted"
         },
         _focusWithin: {
             outline: "2px solid",
@@ -42,7 +45,7 @@ const CheckboxOption = ({
         borderRadius: "0.25rem",
         border: "1px solid",
         borderColor: "border",
-        cursor: "pointer"
+        cursor: disabled ? "not-allowed" : "pointer"
     });
 
     const labelContainerStyles = css({
@@ -56,9 +59,9 @@ const CheckboxOption = ({
         fontWeight: "medium",
         color: "text",
         userSelect: "none",
-        cursor: "pointer",
+        cursor: disabled ? "not-allowed" : "pointer",
         _hover: {
-            color: "text"
+            color: disabled ? "inherit" : "text"
         }
     });
 
@@ -76,6 +79,7 @@ const CheckboxOption = ({
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                     onChange(e.target.checked)
                 }
+                disabled={disabled}
                 aria-label={label}
                 aria-describedby={descriptionId}
                 className={checkboxStyles}

--- a/src/components/options/PasswordCharacterOptions.tsx
+++ b/src/components/options/PasswordCharacterOptions.tsx
@@ -28,21 +28,47 @@ const PasswordCharacterOptions = ({
     spaceY: "2"
   });
 
+  // Count checked character options (excluding excludeAmbiguous)
+  const checkedCount = [
+    options.lowercase,
+    options.uppercase,
+    options.numbers,
+    options.special
+  ].filter(Boolean).length;
+
+  const isLastOption = (key: string) => {
+    // Only main character options can be last, not excludeAmbiguous
+    if (key === "excludeAmbiguous") return false;
+    return checkedCount === 1 && options[key as keyof CharacterOptions];
+  };
+
   return (
     <div
       className={containerStyles}
       role="group"
       aria-label="비밀번호 문자 옵션"
     >
-      {OPTIONS.map(({ key, label, description }) => (
-        <CheckboxOption
-          key={key}
-          checked={options[key]}
-          onChange={(checked) => onOptionsChange({ [key]: checked })}
-          label={label}
-          description={description}
-        />
-      ))}
+      {OPTIONS.map(({ key, label, description }) => {
+        const isDisabled = isLastOption(key);
+        const finalDescription = isDisabled
+          ? `${description} (최소 1개 옵션 필수)`
+          : description;
+
+        return (
+          <CheckboxOption
+            key={key}
+            checked={options[key]}
+            onChange={(checked) => {
+              if (!isDisabled || checked) {
+                onOptionsChange({ [key]: checked });
+              }
+            }}
+            label={label}
+            description={finalDescription}
+            disabled={isDisabled}
+          />
+        );
+      })}
     </div>
   );
 };


### PR DESCRIPTION
## 개요

비밀번호 생성기의 사용자 경험 개선을 위한 3가지 소규모 UX 수정입니다.

## 변경 내용

### 1. 복사 버튼 피드백
- 클릭 시 버튼 텍스트가 "복사하기" → "복사됨 ✓"로 변경
- 1.5초 후 원래 텍스트로 복원
- `showCopyFeedback` 상태로 구현

### 2. 새로고침 아이콘 애니메이션
- 기존: 180도 회전 토글 방식
- 변경: 매 클릭마다 360도 회전하는 한 번의 애니메이션 재생
- Panda CSS에 `spin-once` 키프레임 추가 (0→360도, 0.36s)
- `refreshKey` 상태로 애니메이션 재시작 기술 구현

### 3. 마지막 문자 옵션 보호
- 4가지 문자 옵션(소문자, 대문자, 숫자, 특수) 중 하나만 남으면 해제 불가
- `excludeAmbiguous`는 영향 없음
- 비활성화된 체크박스 시각적 표시 (opacity 60%, 회색 설명 텍스트)
- 설명에 "최소 1개 옵션 필수" 안내 추가

## 검증

- ✅ `npm test` 통과 (12/12 tests)
- ✅ `npm run build` 성공
- ✅ 비활성화 상태 CSS 적용 확인
- ✅ 기존 코드 스타일 유지 (Panda `css()` 함수 사용)

🤖 Generated with [Claude Code](https://claude.com/claude-code)